### PR TITLE
feat(analytics): measure site traffic using goatcounter

### DIFF
--- a/build/template.html
+++ b/build/template.html
@@ -30,5 +30,7 @@
 		</div>
 	</div>
 	<script src="{script}"></script>
+
+	<script data-goatcounter="https://hunterosc.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>


### PR DESCRIPTION
In https://github.com/Hunter-Open-Source-Club/syllabi/issues/31 we discussed what it would look like to gather usage data in an ethical / privacy-respecting manner. Quost:

> I don't think the sort of information we could gather about usage of the
> website could be considered sensitive. What's absolutely off limits is
> turning the site into a sleeper agent by employing Google Analytics and
> gathering users' IPs and browser fingerprints. In fact, using any other
> entity's analytics solution is a bad idea because we don't have control over
> what they do with our users' data. We want a self-hosted solution where we
> own all the data and can assure nothing sensitive is being collected.
>...
> I also think the best part of this would be displaying the analytics on a
> publically accessible page on the website.

We went on to propose a few "hacky" hand-rolled solutions, mostly involving abusing GitHub Actions to store persistent state, given the static nature of the website / GitHub Pages.

Revisiting this some time later, I came across GoatCounter (https://goatcounter.com), "an open source web analytics platform ... [that] aims to offer easy to use and meaningful privacy-friendly web analytics as an alternative to Google Analytics". The author offers a free hosted solution for personal use, which we can plug in to our site with a simple one-line change. This also comes with a dashboard UI for monitoring the analytics, which can be publically accessed at this URL: https://hunterosc.goatcounter.com

Reading through https://www.goatcounter.com/why as well as the author's personal website https://www.arp242.net gives the impression of a person who shares the same concerns we have regarding analytics/telemetry, and has come up with what reads to me as a balanced altruistic solution. So, I've decided to give GoatCounter a try for now.

## Adblockers

GoatCounter's tracking is blocked by adblockers, so any analytics will not include users who have an adblock extension loaded (such as myself :). I did experiment with some shady ways to bypass this to see if it would work (e.g. I tried creating an AWS Lambda function that forwards the request to GoatCounter rather than hitting GoatCounter directly, but my adblocker was clever enough to block that too haha). I imagine in the demographic of college students, many people will be accessing this website from their phone, which presumably does not have an adblocker installed, so perhaps the effect of this will be dialed down. Either way, it will be interesting to see any data about how much traffic we get, complete or incomplete.